### PR TITLE
Fixed delete button error for events

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -39,7 +39,7 @@
 
 
     <% if @event.user == current_user %>
-      <%= button_to event_path(@event), data: {turbo_method: :delete, turbo_confirm: "Are you sure you want to delete?"}, class: "button" do %>
+      <%= link_to event_path(@event), data: {turbo_method: :delete, turbo_confirm: "Are you sure you want to delete?"}, class: "button" do %>
         <i class="fa-sharp fa-regular fa-circle-xmark" style="color: #ffffff;"></i> Delete
       <% end %>
     <% end %>


### PR DESCRIPTION
Fixed an error with events delete button on events show page, where the button was wasn´t able to delete due to button having post requests by default. Button for delete is now a link_to