### PR TITLE
Fixed bug in event delete notification

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -4,7 +4,7 @@ class Event < ApplicationRecord
   has_many :requests, dependent: :destroy
   has_one :chatroom, dependent: :destroy
   has_one_attached :photo, dependent: :destroy
-  has_many :notifications, :as => :notifiable
+  has_many :notifications, :as => :notifiable, dependent: :destroy
   validates :title, :description, :location, :capacity, :start_date, :end_date, presence: true
   geocoded_by :location
   after_validation :geocode, if: :will_save_change_to_location?


### PR DESCRIPTION
Fixed a bug where a notification would persist without content once an event was deleted, by deleting the notifcations of an event completely once an event is deleted.